### PR TITLE
Fix translation service not being set by default

### DIFF
--- a/XCStringsEditor.xcodeproj/project.pbxproj
+++ b/XCStringsEditor.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		19ABC3D82B5BA34C009568D2 /* XCStringsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ABC3D72B5BA34C009568D2 /* XCStringsModel.swift */; };
 		19ABC3DA2B5C0E87009568D2 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 19ABC3D92B5C0E87009568D2 /* Localizable.xcstrings */; };
 		19CE60682BF3A7C600CD190E /* TranslationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CE60672BF3A7C500CD190E /* TranslationStatus.swift */; };
+		C0039DCC2C1CE2E100A93A29 /* UserDefaults+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0039DCB2C1CE2E100A93A29 /* UserDefaults+Keys.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		19ABC3D72B5BA34C009568D2 /* XCStringsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCStringsModel.swift; sourceTree = "<group>"; };
 		19ABC3D92B5C0E87009568D2 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		19CE60672BF3A7C500CD190E /* TranslationStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TranslationStatus.swift; path = XCStringsEditor/TranslationStatus.swift; sourceTree = SOURCE_ROOT; };
+		C0039DCB2C1CE2E100A93A29 /* UserDefaults+Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Keys.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +122,7 @@
 		19ABC3C52B5BA17C009568D2 /* XCStringsEditor */ = {
 			isa = PBXGroup;
 			children = (
+				C0039DCA2C1CE2D500A93A29 /* Extensions */,
 				196D574E2B6FB63A00B2F265 /* Helper */,
 				196FC3D02B6087140066D068 /* Model */,
 				19ABC3C62B5BA17C009568D2 /* XCStringEditorApp.swift */,
@@ -142,6 +145,14 @@
 				19ABC3CF2B5BA17D009568D2 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		C0039DCA2C1CE2D500A93A29 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				C0039DCB2C1CE2E100A93A29 /* UserDefaults+Keys.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -230,6 +241,7 @@
 				196D574B2B6F72B600B2F265 /* LocalizeItem.swift in Sources */,
 				1983DE222BEBBD2B006D8815 /* TranslateService.swift in Sources */,
 				1983DE292BEBC293006D8815 /* XCStringsModel+GoogleTranslate.swift in Sources */,
+				C0039DCC2C1CE2E100A93A29 /* UserDefaults+Keys.swift in Sources */,
 				196FC3D22B6087220066D068 /* XCStrings.swift in Sources */,
 				197E64642B74F8CD008251BE /* Language.swift in Sources */,
 				1983DE2B2BEBC2A9006D8815 /* XCStringsModel+DeepL.swift in Sources */,

--- a/XCStringsEditor/Extensions/UserDefaults+Keys.swift
+++ b/XCStringsEditor/Extensions/UserDefaults+Keys.swift
@@ -1,0 +1,35 @@
+//
+//  UserDefaults+Keys.swift
+//  XCStringsEditor
+//
+//  Created by William Alexander on 14/06/2024.
+//
+
+import Foundation
+
+extension UserDefaults {
+    
+    enum Keys {
+        static var googleTranslateAPIKey = "GoogleTranslateAPIKey"
+        static var deeplAPIKey = "DeeplAPIKey"
+        static var translationService = "TranslateService"
+    }
+    
+    var googleTranslateAPIKey: String {
+        string(forKey: Keys.googleTranslateAPIKey) ?? ""
+    }
+    
+    var deeplAPIKey: String {
+        string(forKey: Keys.deeplAPIKey) ?? ""
+    }
+    
+    var translationService: TranslateService {
+        guard 
+            let rawValue = string(forKey: Keys.translationService),
+            let translationService = TranslateService(rawValue: rawValue)
+        else {
+            return .google
+        }
+        return translationService
+    }
+}

--- a/XCStringsEditor/Helper/Translate/TranslateService.swift
+++ b/XCStringsEditor/Helper/Translate/TranslateService.swift
@@ -20,5 +20,5 @@ enum TranslateService: String, CaseIterable, Identifiable, CustomStringConvertib
           case .deepL:
             return "DeepL"
         }
-    }    
+    }
 }

--- a/XCStringsEditor/Model/XCStringsModel.swift
+++ b/XCStringsEditor/Model/XCStringsModel.swift
@@ -99,16 +99,12 @@ class XCStringsModel {
     var isLoading: Bool = false
 
     init() {
-        if let apiKey = UserDefaults.standard.string(forKey: "GoogleTranslateAPIKey") {
-            GoogleTranslate.shared.configure(apiKey: apiKey)
-        }
-        if let apiKey = UserDefaults.standard.string(forKey: "DeeplAPIKey") {
-            DeepL.shared.configure(apiKey: apiKey)
-        }
-
+        GoogleTranslate.shared.configure(apiKey: UserDefaults.standard.googleTranslateAPIKey)
+        DeepL.shared.configure(apiKey: UserDefaults.standard.deeplAPIKey)
+        
         translateLaterItemsHidden = UserDefaults.standard.bool(forKey: "TranslateLaterItemsHidden")
         staleItemsHidden = UserDefaults.standard.bool(forKey: "StaleItemsHidden")
-
+        
 //        searchText.publisher
 //            .debounce(for: 0.2, scheduler: RunLoop.main)
 //            .removeDuplicates()
@@ -676,17 +672,11 @@ class XCStringsModel {
     func translate(ids: Set<LocalizeItem.ID>? = nil) async {
         isLoading = true
         
-        let translateService = TranslateService(rawValue: UserDefaults.standard.string(forKey: "TranslateService") ?? "")
-        
-        switch translateService {
+        switch UserDefaults.standard.translationService {
         case .google:
             await translateByGoogle(ids: ids)
-            
         case .deepL:
             await translateByDeepL(ids: ids)
-            
-        default:
-            showAPIKeyAlert = true
         }
 //        reloadData()
         
@@ -695,16 +685,12 @@ class XCStringsModel {
     
     func reverseTranslate(ids: Set<LocalizeItem.ID>? = nil) {
         isLoading = true
-
-        let translateService = TranslateService(rawValue: UserDefaults.standard.string(forKey: "TranslateService") ?? "")
         
-        switch translateService {
+        switch UserDefaults.standard.translationService {
         case .google:
             reverseTranslateByGoogle(ids: ids)
         case .deepL:
             reverseTranslateByDeepL(ids: ids)
-        default:
-            showAPIKeyAlert = true
         }
 //        reloadData()
         

--- a/XCStringsEditor/SettingsView.swift
+++ b/XCStringsEditor/SettingsView.swift
@@ -8,28 +8,22 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("GoogleTranslateAPIKey") var googleTranslateAPIKey = ""
-    @AppStorage("DeeplAPIKey") var deeplAPIKey = ""
-    @AppStorage("TranslateService") var translateService: TranslateService = .google
     
-    @State private var translateServiceOption: TranslateService = .google
-
+    @AppStorage(UserDefaults.Keys.googleTranslateAPIKey) var googleTranslateAPIKey = ""
+    @AppStorage(UserDefaults.Keys.deeplAPIKey) var deeplAPIKey = ""
+    @AppStorage(UserDefaults.Keys.translationService) var translateService: TranslateService = .google
+    
     var body: some View {
         Form {
-            Picker("Translate Service", selection: $translateServiceOption) {
+            Picker("Translate Service", selection: $translateService) {
                 ForEach(TranslateService.allCases) { option in
                     Text(String(describing: option))
+                        .tag(option)
                 }
             }
             TextField("Google Translate API Key", text: $googleTranslateAPIKey)
             TextField("DeepL API Key", text: $deeplAPIKey)
         }
-        .onAppear {
-            translateServiceOption = translateService
-        }
-        .onChange(of: translateServiceOption, {
-            translateService = translateServiceOption
-        })
         .padding()
         .frame(width: 500, height: 250)
     }


### PR DESCRIPTION
When first installing the app, if you set your API key then you'd still get the 'API key not set' warning. This was due to the translation service not being set. 

This PR changes how this value is read from UserDefaults so that it can default to `google`, since that's what the picker did anyway so I've kept that functionality. I've also updated the picker so that a duplication of the `@State` isn't required.

First PR in this repo, hope it's alright. 👍🏼 